### PR TITLE
Maintenance

### DIFF
--- a/configuration/logstash.testing.config
+++ b/configuration/logstash.testing.config
@@ -2,13 +2,13 @@ input {
   file {
     id => "tuxedomask.nginx.access.input.file"
     type => "tuxedomask.nginx.access"
-    path => [ "/var/log/nginx/access.log" ]
+    path => [ "/var/log/nginx/access.log.*" ]
     codec => plain
   }
   file {
     id => "tuxedomask.uwsgi.access.input.file"
     type => "tuxedomask.uwsgi.access"
-    path => [ "/var/log/uwsgi/uwsgi.log" ]
+    path => [ "/var/log/uwsgi/uwsgi.log.*" ]
     codec => plain
   }
 }

--- a/configuration/uwsgi.testing.config
+++ b/configuration/uwsgi.testing.config
@@ -10,4 +10,4 @@ uid = ubuntu
 gid = tuxedo_mask
 
 die-on-term = true
-logto = /var/log/uwsgi/uwsgi.testing.log
+logto = /var/log/uwsgi/uwsgi.log

--- a/scripts/upstart/logstash.testing.conf
+++ b/scripts/upstart/logstash.testing.conf
@@ -5,7 +5,7 @@ stop on runlevel [06]
 
 respawn
 
-env ENVIRONMENT="Testing"
+env ENVIRONMENT="testing"
 env TUXEDOMASK_CONFIGURATION_DIRECTORY_PATH="/opt/tuxedomask/configuration/"
 
-exec /opt/logstash/bin/logstash --path.config ${TUXEDOMASK_CONFIGURATION_DIRECTORY}/logstash.${ENVIRONMENT,,}.config
+exec /opt/logstash/bin/logstash --path.config $TUXEDOMASK_CONFIGURATION_DIRECTORY/logstash.$ENVIRONMENT.config


### PR DESCRIPTION
- Fixed Logstash file path patterns not matching all files
- Fixed Logstash Upstart configuration file using bash instead of sh
- Fixed uWSGI default log file path configuration value